### PR TITLE
Overhaul of SpinWeightedSpheroidalHarmonics.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpinWeightedSpheroidalHarmonics"
 uuid = "680e17a6-2a17-48fd-ae01-e2b5a643bef0"
 authors = ["Rico Ka Lok Lo"]
-version = "0.4.0"
+version = "0.5.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/docs/src/APIs.md
+++ b/docs/src/APIs.md
@@ -1,17 +1,6 @@
 # APIs
 
-```@docs
-spin_weighted_spheroidal_harmonic
-```
-
-```@docs
-spin_weighted_spheroidal_eigenvalue
-```
-
-```@docs
-spin_weighted_spherical_harmonic
-```
-
-```@docs
-spin_weighted_spherical_eigenvalue
+```@autodocs
+Modules = [SpinWeightedSpheroidalHarmonics]
+Order   = [:function, :type]
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -45,7 +45,9 @@ For example, to compute the spin-weighted spheroidal harmonic for the mode $s = 
 using SpinWeightedSpheroidalHarmonics
 s=-2; l=2; m=2; a=0.7; omega=0.5;
 theta=π/6; phi=π/3;
-spin_weighted_spheroidal_harmonic(s, l, m, a*omega, theta, phi)
+# Construct the SpinWeightedSpheroidalHarmonicFunction
+swsh = spin_weighted_spheroidal_harmonic(s, l, m, a*omega)
+swsh(theta, phi)
 ```
 
 ## License

--- a/src/SpinWeightedSpheroidalHarmonics.jl
+++ b/src/SpinWeightedSpheroidalHarmonics.jl
@@ -70,7 +70,11 @@ end
 @doc raw"""
     spin_weighted_spheroidal_harmonic(s::Int, l::Int, m::Int, c; N::Int=10)
 
-Compute the spin-weighted spheroidal harmonic.
+Construct the spectral decomposition of this spin-weighted spheroidal harmonic of 
+spin weight `s`, harmonic index `l`, azimuthal index `m`, and spheroidicity `c` ($c = a\omega$) 
+using `N` spin-weighted *spherical* harmonics.
+
+Return a SpinWeightedSpheroidalHarmonicFunction object that can be evaluated at any point.
 """
 function spin_weighted_spheroidal_harmonic(s::Int, l::Int, m::Int, c; N::Int=10)
     coefficients_params = SpectralDecompositionInputParams(s, l, m, c, N)
@@ -83,14 +87,34 @@ function spin_weighted_spheroidal_harmonic(s::Int, l::Int, m::Int, c; N::Int=10)
 end
 
 # The power of multiple dispatch
+@doc raw"""
+    SpinWeightedSpheroidalHarmonicFunction(theta, phi; theta_derivative::Int=0, phi_derivative::Int=0)
+
+Compute the value of the spin-weighted spheroidal harmonic at the point `(theta, phi)`. 
+Additionally compute the `theta_derivative`-th derivative with respect to `theta` and the `phi_derivative`-th derivative with respect to `phi` exactly.
+"""
 (swsh_func::SpinWeightedSpheroidalHarmonicFunction)(theta, phi; theta_derivative::Int=0, phi_derivative::Int=0) = begin
     _unnormalized_spin_weighted_spheroidal_harmonic(swsh_func.params, swsh_func.coeffs, theta, phi; theta_derivative=theta_derivative, phi_derivative=phi_derivative) / swsh_func.normalization_const
 end
 
+@doc raw"""
+    spin_weighted_spherical_harmonic(s::Int, l::Int, m::Int)
+
+Construct the spin-weighted spherical harmonic of 
+spin weight `s`, harmonic index `l`, and azimuthal index `m`.
+
+Return a SpinWeightedSphericalHarmonicFunction object that can be evaluated at any point.
+"""
 function spin_weighted_spherical_harmonic(s::Int, l::Int, m::Int)
     return SpinWeightedSphericalHarmonicFunction(s, l, m, spin_weighted_spherical_eigenvalue(s, l, m))
 end
 
+@doc raw"""
+    SpinWeightedSphericalHarmonicFunction(theta, phi; theta_derivative::Int=0, phi_derivative::Int=0)
+
+Compute the exact value of the spin-weighted spherical harmonic at the point `(theta, phi)`.
+Additionally compute the `theta_derivative`-th derivative with respect to `theta` and the `phi_derivative`-th derivative with respect to `phi` exactly.
+"""
 (swsh_func::SpinWeightedSphericalHarmonicFunction)(theta, phi; theta_derivative::Int=0, phi_derivative::Int=0) = begin
     _nth_derivative_spherical_harmonic(swsh_func.s, swsh_func.l, swsh_func.m, theta_derivative, phi_derivative, theta, phi)
 end

--- a/src/harmonic.jl
+++ b/src/harmonic.jl
@@ -80,14 +80,3 @@ function _swsh_prefactor(s::Int, l::Int, m::Int)
     end
     # should throw an error here because the function should have exited before this
 end
-
-@doc raw"""
-    spin_weighted_spherical_harmonic(s::Int, l::Int, m::Int, theta, phi; theta_derivative::Int=0, phi_derivative::Int=0)
-
-Compute the spin-weighted spherical harmonic with spin weight `s`, harmonic index `l`, azimuthal index `m`, and coordinates `theta` and `phi`.
-
-The optional arguments `theta_derivative` and `phi_derivative` specify the order of partial derivatives to take with respect to `theta` and `phi`, respectively.
-"""
-function spin_weighted_spherical_harmonic(s::Int, l::Int, m::Int, theta, phi; theta_derivative::Int=0, phi_derivative::Int=0)
-    _nth_derivative_spherical_harmonic(s, l, m, theta_derivative, phi_derivative, theta, phi)
-end


### PR DESCRIPTION
The PR introduces yet another overhaul of the package.

In particular we stop use the interface
`spin_weighted_spheroidal_harmonic(s, l, m, ..., theta, phi; theta_derivative, ..., N::Int)` and similarly 
`spin_weighted_spherical_harmonic(s, l, m, theta, phi; ...)`.  Instead `spin_weighted_spheroidal_harmonic` now returns a `SpinWeightedSpheroidalHarmonicFunction` that stores the spectral decomposition coefficients and can be invoked to get the value of the harmonic at any point. This eliminates the previously-implemented caching mechanism.