### PR TITLE
Stable evaluation for large l using Chebyshev pseudo-spectral method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SpinWeightedSpheroidalHarmonics"
 uuid = "680e17a6-2a17-48fd-ae01-e2b5a643bef0"
 authors = ["Rico Ka Lok Lo"]
-version = "0.5.3"
+version = "0.5.4"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/Project.toml
+++ b/Project.toml
@@ -6,11 +6,13 @@ version = "0.5.3"
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 ApproxFun = "28f2ccd6-bb30-5033-b560-165f7b14dc2f"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 AbstractTrees = "0.4.2"
 ApproxFun = "^0.13"
+ForwardDiff = "0.10"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -6,13 +6,13 @@ version = "0.5.3"
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 ApproxFun = "28f2ccd6-bb30-5033-b560-165f7b14dc2f"
-ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 
 [compat]
 AbstractTrees = "0.4.2"
 ApproxFun = "^0.13"
-ForwardDiff = "0.10"
+TaylorSeries = "0.15"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -5,10 +5,12 @@ version = "0.5.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+ApproxFun = "28f2ccd6-bb30-5033-b560-165f7b14dc2f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 AbstractTrees = "0.4.2"
+ApproxFun = "^0.13"
 julia = "1"
 
 [extras]

--- a/src/SpinWeightedSpheroidalHarmonics.jl
+++ b/src/SpinWeightedSpheroidalHarmonics.jl
@@ -80,12 +80,17 @@ end
 
 # The power of multiple dispatch
 @doc raw"""
-    SpinWeightedSpheroidalHarmonicFunction(theta, phi; theta_derivative::Int=0, phi_derivative::Int=0)
+    SpinWeightedSpheroidalHarmonicFunction(theta, phi; theta_derivative::Int=0, phi_derivative::Int=0, method="auto")
 
 Compute the value of the spin-weighted spheroidal harmonic at the point `(theta, phi)`. 
 Additionally compute the `theta_derivative`-th derivative with respect to `theta` and the `phi_derivative`-th derivative with respect to `phi` exactly.
+
+By default, the method used to compute the value is chosen automatically based on the value of the harmonic index `l`.
+When `l < 30`, the direct evaluation method (`method="direct"`) is used where we evaluate the exact analytical solution as shown in Eq. (A8).
+However, the prefactor in each term of the sum can be very large and thus cause overflow, while the sum itself is finite (of order 1 actually).
+Therefore, when `l >= 30`, the Chebyshev pseudo-spectral method (`method="chebyshev"`) is used instead.
 """
-(swsh_func::SpinWeightedSpheroidalHarmonicFunction)(theta, phi; theta_derivative::Int=0, phi_derivative::Int=0) = begin
+(swsh_func::SpinWeightedSpheroidalHarmonicFunction)(theta, phi; theta_derivative::Int=0, phi_derivative::Int=0, method="auto") = begin
     _unnormalized_spin_weighted_spheroidal_harmonic(swsh_func.params, swsh_func.coeffs, theta, phi; theta_derivative=theta_derivative, phi_derivative=phi_derivative) / swsh_func.normalization_const
 end
 
@@ -104,7 +109,7 @@ end
 @doc raw"""
     SpinWeightedSphericalHarmonicFunction(theta, phi; theta_derivative::Int=0, phi_derivative::Int=0)
 
-Compute the exact value of the spin-weighted spherical harmonic at the point `(theta, phi)`.
+Compute the value of the spin-weighted spherical harmonic at the point `(theta, phi)`.
 Additionally compute the `theta_derivative`-th derivative with respect to `theta` and the `phi_derivative`-th derivative with respect to `phi` exactly.
 """
 (swsh_func::SpinWeightedSphericalHarmonicFunction)(theta, phi; theta_derivative::Int=0, phi_derivative::Int=0) = begin


### PR DESCRIPTION
As titled. This is to battle the problem with overflow when the harmonic index $\ell$ is large (at around $\ell \approx 30$) where the prefactor in each term of the summation in the exact solution we use gets (factorially) large and causing overflow. Therefore, the code will automatically switch to using Chebyshev pseudo-spectral method to solve the BVP problem to get the spin-weighted spherical harmonic numerically.