### PR TITLE
Split Chebyshev domain

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,12 +7,14 @@ version = "0.5.4"
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 ApproxFun = "28f2ccd6-bb30-5033-b560-165f7b14dc2f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LogarithmicNumbers = "aa2f6b4e-9042-5d33-9679-40d3a6b85899"
 TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 
 [compat]
 AbstractTrees = "0.4.2"
 ApproxFun = "^0.13"
 TaylorSeries = "0.15"
+LogarithmicNumbers = "^1.14"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 AbstractTrees = "0.4.2"
 ApproxFun = "^0.13"
 TaylorSeries = "0.15"
-LogarithmicNumbers = "^1.14"
+LogarithmicNumbers = "^1"
 julia = "1"
 
 [extras]

--- a/src/SpinWeightedSpheroidalHarmonics.jl
+++ b/src/SpinWeightedSpheroidalHarmonics.jl
@@ -29,12 +29,12 @@ function Base.show(io::IO, ::MIME"text/plain", swsh_func::SpinWeightedSpheroidal
     print(io, "SpinWeightedSpheroidalHarmonicFunction(s = $(swsh_func.params.s), l = $(swsh_func.params.l), m = $(swsh_func.params.m), c = $(swsh_func.params.c), lambda = $(swsh_func.lambda))")
 end
 
-# Not really necessary but this is to maintain uniformity
 struct SpinWeightedSphericalHarmonicFunction
     s::Int
     l::Int
     m::Int
     lambda
+    chebyshev_solution
 end
 
 # Implement pretty printing for SpinWeightedSphericalHarmonicFunction
@@ -42,19 +42,19 @@ function Base.show(io::IO, ::MIME"text/plain", swsh_func::SpinWeightedSphericalH
     print(io, "SpinWeightedSphericalHarmonicFunction(s = $(swsh_func.s), l = $(swsh_func.l), m = $(swsh_func.m), lambda = $(swsh_func.lambda))")
 end
 
-function _unnormalized_spin_weighted_spheroidal_harmonic(coefficients_params, coefficients, theta, phi; theta_derivative::Int=0, phi_derivative::Int=0)
+function _unnormalized_spin_weighted_spheroidal_harmonic(coefficients_params, coefficients, spherical_harmonics_l, theta, phi; theta_derivative::Int=0, phi_derivative::Int=0)
     # Compute the spin-weighted spherical harmonics needed
     output = 0.0
-    spherical_harmonics_l = construct_all_l_in_matrix(coefficients_params.s, coefficients_params.m, coefficients_params.N)
+    l_list = construct_all_l_in_matrix(coefficients_params.s, coefficients_params.m, coefficients_params.N)
 
-    for (idx, spherical_harmonic_l) in enumerate(spherical_harmonics_l)
-        output += coefficients[idx] * _nth_derivative_spherical_harmonic(coefficients_params.s, spherical_harmonic_l, coefficients_params.m, theta_derivative, phi_derivative, theta, phi)
+    for (idx, _) in enumerate(l_list)
+        output += coefficients[idx] * spherical_harmonics_l[idx](theta, phi; theta_derivative=theta_derivative, phi_derivative=phi_derivative)
     end
     output
 end
 
 @doc raw"""
-    spin_weighted_spheroidal_harmonic(s::Int, l::Int, m::Int, c; N::Int=-1)
+    spin_weighted_spheroidal_harmonic(s::Int, l::Int, m::Int, c; N::Int=-1, method="auto")
 
 Construct the spectral decomposition of this spin-weighted spheroidal harmonic of 
 spin weight `s`, harmonic index `l`, azimuthal index `m`, and spheroidicity `c` ($c = a\omega$) 
@@ -64,14 +64,23 @@ Note that the default value for `N=-1` indicates that a suitable value of `N`
 will be determined automatically.
 
 Return a SpinWeightedSpheroidalHarmonicFunction object that can be evaluated at any point.
+
+By default, the method to compute the value for the underlying spin-weighted spherical harmonics 
+is chosen automatically based on the value of the harmonic index `l`.
+When `l < 30`, the direct evaluation method (`method="direct"`) is used where we evaluate the exact analytical solution as shown in Eq. (A8).
+However, the prefactor in each term of the sum can be very large and thus cause overflow, while the sum itself is finite (of order 1 actually).
+Therefore, when `l >= 30`, the Chebyshev pseudo-spectral method (`method="chebyshev"`) is used instead.
 """
-function spin_weighted_spheroidal_harmonic(s::Int, l::Int, m::Int, c; N::Int=-1)
+function spin_weighted_spheroidal_harmonic(s::Int, l::Int, m::Int, c; N::Int=-1, method="auto")
     if N == -1
         N = _determine_matrix_size_N(s, l, m)
     end
     coefficients_params = SpectralDecompositionInputParams(s, l, m, c, N)
     coefficients = spectral_coefficients(c, s, l, m, N)
-    spherical_harmonics_l = construct_all_l_in_matrix(coefficients_params.s, coefficients_params.m, coefficients_params.N)
+    l_list = construct_all_l_in_matrix(coefficients_params.s, coefficients_params.m, coefficients_params.N)
+    spherical_harmonics_l = [
+        spin_weighted_spherical_harmonic(s, l, m; method=method) for l in l_list
+    ]
     normalization = 1 # already satisfied the normalization cond. \int_{0}^{pi} [nf*S(theta)]^2 sin(theta) d theta = 1
     lambda = spin_weighted_spheroidal_eigenvalue(s, l, m, c, N=N) # Not the most efficient way to do this, but it works
 
@@ -80,30 +89,43 @@ end
 
 # The power of multiple dispatch
 @doc raw"""
-    SpinWeightedSpheroidalHarmonicFunction(theta, phi; theta_derivative::Int=0, phi_derivative::Int=0, method="auto")
+    SpinWeightedSpheroidalHarmonicFunction(theta, phi; theta_derivative::Int=0, phi_derivative::Int=0)
 
 Compute the value of the spin-weighted spheroidal harmonic at the point `(theta, phi)`. 
 Additionally compute the `theta_derivative`-th derivative with respect to `theta` and the `phi_derivative`-th derivative with respect to `phi` exactly.
-
-By default, the method used to compute the value is chosen automatically based on the value of the harmonic index `l`.
-When `l < 30`, the direct evaluation method (`method="direct"`) is used where we evaluate the exact analytical solution as shown in Eq. (A8).
-However, the prefactor in each term of the sum can be very large and thus cause overflow, while the sum itself is finite (of order 1 actually).
-Therefore, when `l >= 30`, the Chebyshev pseudo-spectral method (`method="chebyshev"`) is used instead.
 """
-(swsh_func::SpinWeightedSpheroidalHarmonicFunction)(theta, phi; theta_derivative::Int=0, phi_derivative::Int=0, method="auto") = begin
-    _unnormalized_spin_weighted_spheroidal_harmonic(swsh_func.params, swsh_func.coeffs, theta, phi; theta_derivative=theta_derivative, phi_derivative=phi_derivative) / swsh_func.normalization_const
+(swsh_func::SpinWeightedSpheroidalHarmonicFunction)(theta, phi; theta_derivative::Int=0, phi_derivative::Int=0) = begin
+    _unnormalized_spin_weighted_spheroidal_harmonic(swsh_func.params, swsh_func.coeffs, swsh_func.spherical_harmonics_l, theta, phi; theta_derivative=theta_derivative, phi_derivative=phi_derivative) / swsh_func.normalization_const
 end
 
 @doc raw"""
-    spin_weighted_spherical_harmonic(s::Int, l::Int, m::Int)
+    spin_weighted_spherical_harmonic(s::Int, l::Int, m::Int; method="auto")
 
 Construct the spin-weighted spherical harmonic of 
 spin weight `s`, harmonic index `l`, and azimuthal index `m`.
 
 Return a SpinWeightedSphericalHarmonicFunction object that can be evaluated at any point.
+
+By default, the method to compute the value is chosen automatically based on the value of the harmonic index `l`.
+When `l < 30`, the direct evaluation method (`method="direct"`) is used where we evaluate the exact analytical solution as shown in Eq. (A8).
+However, the prefactor in each term of the sum can be very large and thus cause overflow, while the sum itself is finite (of order 1 actually).
+Therefore, when `l >= 30`, the Chebyshev pseudo-spectral method (`method="chebyshev"`) is used instead.
 """
-function spin_weighted_spherical_harmonic(s::Int, l::Int, m::Int)
-    return SpinWeightedSphericalHarmonicFunction(s, l, m, spin_weighted_spherical_eigenvalue(s, l, m))
+function spin_weighted_spherical_harmonic(s::Int, l::Int, m::Int; method="auto")
+    if method == "auto"
+        _method = l >= 30 ? "chebyshev" : "direct"
+    elseif method == "direct" || method == "chebyshev"
+        _method = method
+    else
+        error("Does not understand method $method")
+    end
+
+    if _method == "direct"
+        return SpinWeightedSphericalHarmonicFunction(s, l, m, spin_weighted_spherical_eigenvalue(s, l, m), nothing)
+    else
+        chebyshev_soln = _solve_spherical_harmonic_chebyshev(s, l, m)
+        return SpinWeightedSphericalHarmonicFunction(s, l, m, spin_weighted_spherical_eigenvalue(s, l, m), chebyshev_soln)
+    end
 end
 
 @doc raw"""
@@ -113,7 +135,11 @@ Compute the value of the spin-weighted spherical harmonic at the point `(theta, 
 Additionally compute the `theta_derivative`-th derivative with respect to `theta` and the `phi_derivative`-th derivative with respect to `phi` exactly.
 """
 (swsh_func::SpinWeightedSphericalHarmonicFunction)(theta, phi; theta_derivative::Int=0, phi_derivative::Int=0) = begin
-    _nth_derivative_spherical_harmonic(swsh_func.s, swsh_func.l, swsh_func.m, theta_derivative, phi_derivative, theta, phi)
+    if isnothing(swsh_func.chebyshev_solution)
+        return _nth_derivative_spherical_harmonic_direct_eval(swsh_func.s, swsh_func.l, swsh_func.m, theta_derivative, phi_derivative, theta, phi)
+    else
+        return _nth_derivative_spherical_harmonic_chebyshev(swsh_func.chebyshev_solution, swsh_func.m, theta_derivative, phi_derivative, theta, phi)
+    end
 end
 
 @doc raw"""

--- a/src/SpinWeightedSpheroidalHarmonics.jl
+++ b/src/SpinWeightedSpheroidalHarmonics.jl
@@ -8,27 +8,6 @@ include("spectral.jl")
 export spin_weighted_spheroidal_harmonic, spin_weighted_spherical_harmonic, spin_weighted_spheroidal_eigenvalue, spin_weighted_spherical_eigenvalue # Expose these functions to the user
 export Teukolsky_lambda_const # For backward compatbility
 
-struct SpectralDecompositionInputParams
-    s::Int
-    l::Int
-    m::Int
-    c
-    N::Int
-end
-
-struct SpinWeightedSpheroidalHarmonicFunction
-    params::SpectralDecompositionInputParams
-    coeffs
-    spherical_harmonics_l
-    normalization_const
-    lambda
-end
-
-# Implement pretty printing for SpinWeightedSpheroidalHarmonicFunction
-function Base.show(io::IO, ::MIME"text/plain", swsh_func::SpinWeightedSpheroidalHarmonicFunction)
-    print(io, "SpinWeightedSpheroidalHarmonicFunction(s = $(swsh_func.params.s), l = $(swsh_func.params.l), m = $(swsh_func.params.m), c = $(swsh_func.params.c), lambda = $(swsh_func.lambda))")
-end
-
 struct SpinWeightedSphericalHarmonicFunction
     s::Int
     l::Int
@@ -40,6 +19,27 @@ end
 # Implement pretty printing for SpinWeightedSphericalHarmonicFunction
 function Base.show(io::IO, ::MIME"text/plain", swsh_func::SpinWeightedSphericalHarmonicFunction)
     print(io, "SpinWeightedSphericalHarmonicFunction(s = $(swsh_func.s), l = $(swsh_func.l), m = $(swsh_func.m), lambda = $(swsh_func.lambda))")
+end
+
+struct SpectralDecompositionInputParams
+    s::Int
+    l::Int
+    m::Int
+    c
+    N::Int
+end
+
+struct SpinWeightedSpheroidalHarmonicFunction
+    params::SpectralDecompositionInputParams
+    coeffs
+    spherical_harmonics_l::Vector{SpinWeightedSphericalHarmonicFunction}
+    normalization_const
+    lambda
+end
+
+# Implement pretty printing for SpinWeightedSpheroidalHarmonicFunction
+function Base.show(io::IO, ::MIME"text/plain", swsh_func::SpinWeightedSpheroidalHarmonicFunction)
+    print(io, "SpinWeightedSpheroidalHarmonicFunction(s = $(swsh_func.params.s), l = $(swsh_func.params.l), m = $(swsh_func.params.m), c = $(swsh_func.params.c), lambda = $(swsh_func.lambda))")
 end
 
 function _unnormalized_spin_weighted_spheroidal_harmonic(coefficients_params, coefficients, spherical_harmonics_l, theta, phi; theta_derivative::Int=0, phi_derivative::Int=0)


### PR DESCRIPTION
In this PR, we solve the problem with using the Chebyshev pseudo-spectral method being unable to return "non-trivial" solution when both boundary values (at $\theta = 0$ and $\theta = \pi$) vanish.

The technique/trick here is to compute the value at $\theta = \pi/2$ using arbitrary precision algorithms, and split the domain into $[0, \pi/2]$ and $[\pi/2, 0]$ where the value at the boundaries will not be both vanishing.