### PR TITLE
Implement Jacobi polynomial recurrence relation

### DIFF
--- a/src/SpinWeightedSpheroidalHarmonics.jl
+++ b/src/SpinWeightedSpheroidalHarmonics.jl
@@ -10,7 +10,7 @@ export Teukolsky_lambda_const # For backward compatbility
 
 _TOLERANCE = 1e-16 # Spherical harmonics smaller than this will be ignored in the spectral decomposition
 
-function _normalize_spherical_method(method)
+function _format_method_name(method)
     normalized = lowercase(strip(String(method)))
     if normalized == "auto" || normalized == "direct" || normalized == "chebyshev" || normalized == "jacobi"
         return normalized
@@ -46,11 +46,13 @@ struct SpinWeightedSpheroidalHarmonicFunction
     spherical_harmonics_l::Vector{Union{SpinWeightedSphericalHarmonicFunction, Nothing}}
     normalization_const
     lambda
+    method::Symbol
+    chebyshev_solution
 end
 
 # Implement pretty printing for SpinWeightedSpheroidalHarmonicFunction
 function Base.show(io::IO, ::MIME"text/plain", swsh_func::SpinWeightedSpheroidalHarmonicFunction)
-    print(io, "SpinWeightedSpheroidalHarmonicFunction(s = $(swsh_func.params.s), l = $(swsh_func.params.l), m = $(swsh_func.params.m), c = $(swsh_func.params.c), lambda = $(swsh_func.lambda))")
+    print(io, "SpinWeightedSpheroidalHarmonicFunction(s = $(swsh_func.params.s), l = $(swsh_func.params.l), m = $(swsh_func.params.m), c = $(swsh_func.params.c), method = $(swsh_func.method), lambda = $(swsh_func.lambda))")
 end
 
 function _unnormalized_spin_weighted_spheroidal_harmonic(coefficients_params, coefficients, spherical_harmonics_l, theta, phi; theta_derivative::Int=0, phi_derivative::Int=0)
@@ -64,7 +66,34 @@ function _unnormalized_spin_weighted_spheroidal_harmonic(coefficients_params, co
         end
         output += coefficients[idx] * spherical_harmonics_l[idx](theta, phi; theta_derivative=theta_derivative, phi_derivative=phi_derivative)
     end
-    output
+    return output
+end
+
+function _spheroidal_boundary_values(coefficients_params, coefficients)
+    s = coefficients_params.s
+    m = coefficients_params.m
+    l_list = construct_all_l_in_matrix(s, m, coefficients_params.N)
+
+    S0 = zero(eltype(coefficients))
+    Spi2 = zero(eltype(coefficients))
+    Spi = zero(eltype(coefficients))
+
+    for idx in eachindex(l_list)
+        if abs(coefficients[idx]) < _TOLERANCE
+            continue
+        end
+
+        l = l_list[idx]
+        Y0 = m == -s ? (-1)^s * sqrt((2 * l + 1) / (4π)) : 0.0
+        Ypi2 = Float64(spin_weighted_spherical_harmonic_at_pi_over_2(s, l, m))
+        Ypi = m == s ? (-1)^l * sqrt((2 * l + 1) / (4π)) : 0.0
+
+        S0 += coefficients[idx] * Y0
+        Spi2 += coefficients[idx] * Ypi2
+        Spi += coefficients[idx] * Ypi
+    end
+
+    return S0, Spi2, Spi
 end
 
 @doc raw"""
@@ -79,26 +108,33 @@ will be determined automatically.
 
 Return a SpinWeightedSpheroidalHarmonicFunction object that can be evaluated at any point.
 
-By default, the method to compute the value for the underlying spin-weighted spherical harmonics 
-is chosen automatically based on the value of the harmonic index `l`.
-When `l < 30`, the direct evaluation method (`method="direct"`) is used where we evaluate the exact analytical solution as shown in Eq. (A8).
-When `l >= 30`, we use a Jacobi polynomial recurrence (`method="jacobi"`) for better high-`l` stability and speed.
-The Chebyshev pseudo-spectral method (`method="chebyshev"`) remains available as an explicit option.
+The `method` argument controls how the harmonic is evaluated:
+- `"auto"`: use spectral decomposition with automatic spherical-harmonic backend selection,
+- `"direct"` or `"jacobi"`: use spectral decomposition with that spherical-harmonic backend,
+- `"chebyshev"`: solve the spheroidal ODE directly with Chebyshev pseudo-spectral collocation.
 Method names are case-insensitive.
 """
 function spin_weighted_spheroidal_harmonic(s::Int, l::Int, m::Int, c; N::Int=-1, method="auto")
     if N == -1
         N = _determine_matrix_size_N(s, l, m)
     end
-    normalized_method = _normalize_spherical_method(method)
+    method = _format_method_name(method)
     coefficients_params = SpectralDecompositionInputParams(s, l, m, c, N)
-    angular, coefficients = _spectral_mode_solution(c, s, l, m, N)
-    l_list = construct_all_l_in_matrix(coefficients_params.s, coefficients_params.m, coefficients_params.N)
-    spherical_harmonics_l = [ abs(coefficients[n]) >= _TOLERANCE ? spin_weighted_spherical_harmonic(s, l_list[n], m; method=normalized_method) : nothing for n in eachindex(l_list) ]
+    angular_sep, coefficients = _spectral_decomposition(c, s, l, m, N)
     normalization = 1 # already satisfied the normalization cond. \int_{0}^{pi} [nf*S(theta)]^2 sin(theta) d theta = 1
-    lambda = angular + c^2 - 2*m*c
+    lambda = angular_sep + c^2 - 2*m*c
 
-    return SpinWeightedSpheroidalHarmonicFunction(coefficients_params, coefficients, spherical_harmonics_l, normalization, lambda)
+    l_list = construct_all_l_in_matrix(coefficients_params.s, coefficients_params.m, coefficients_params.N)
+    if method == "chebyshev"
+        S0, Spi2, Spi = _spheroidal_boundary_values(coefficients_params, coefficients)
+        chebyshev_solution = Fun(_solve_spheroidal_harmonic_chebyshev(s, m, c, lambda, S0, Spi2, Spi), 0..π)
+        spherical_harmonics_l = Vector{Union{SpinWeightedSphericalHarmonicFunction, Nothing}}(undef, length(l_list))
+        fill!(spherical_harmonics_l, nothing)
+        return SpinWeightedSpheroidalHarmonicFunction(coefficients_params, coefficients, spherical_harmonics_l, normalization, lambda, :chebyshev, chebyshev_solution)
+    elseif method != "chebyshev"
+        spherical_harmonics_l = [ abs(coefficients[n]) >= _TOLERANCE ? spin_weighted_spherical_harmonic(s, l_list[n], m; method=method) : nothing for n in eachindex(l_list) ]
+        return SpinWeightedSpheroidalHarmonicFunction(coefficients_params, coefficients, spherical_harmonics_l, normalization, lambda, :spectral, nothing)
+    end
 end
 
 # The power of multiple dispatch
@@ -109,7 +145,11 @@ Compute the value of the spin-weighted spheroidal harmonic at the point `(theta,
 Additionally compute the `theta_derivative`-th derivative with respect to `theta` and the `phi_derivative`-th derivative with respect to `phi` exactly.
 """
 (swsh_func::SpinWeightedSpheroidalHarmonicFunction)(theta, phi; theta_derivative::Int=0, phi_derivative::Int=0) = begin
-    _unnormalized_spin_weighted_spheroidal_harmonic(swsh_func.params, swsh_func.coeffs, swsh_func.spherical_harmonics_l, theta, phi; theta_derivative=theta_derivative, phi_derivative=phi_derivative) / swsh_func.normalization_const
+    if swsh_func.method == :spectral
+        return _unnormalized_spin_weighted_spheroidal_harmonic(swsh_func.params, swsh_func.coeffs, swsh_func.spherical_harmonics_l, theta, phi; theta_derivative=theta_derivative, phi_derivative=phi_derivative) / swsh_func.normalization_const
+    elseif swsh_func.method == :chebyshev
+        return _nth_derivative_spheroidal_harmonic_chebyshev(swsh_func.chebyshev_solution, swsh_func.params.m, theta_derivative, phi_derivative, theta, phi) / swsh_func.normalization_const
+    end
 end
 
 @doc raw"""
@@ -122,26 +162,24 @@ Return a SpinWeightedSphericalHarmonicFunction object that can be evaluated at a
 
 By default, the method to compute the value is chosen automatically based on the value of the harmonic index `l`.
 When `l < 30`, the direct evaluation method (`method="direct"`) is used where we evaluate the exact analytical solution as shown in Eq. (A8).
-When `l >= 30`, we use a Jacobi polynomial recurrence (`method="jacobi"`) for better high-`l` stability and speed.
+When `l >= 30`, we use a Jacobi polynomial recurrence (`method="jacobi"`) for better high-`l` stability and speed (see https://arxiv.org/abs/2208.03691).
 The Chebyshev pseudo-spectral method (`method="chebyshev"`) remains available as an explicit option.
 Method names are case-insensitive.
 """
 function spin_weighted_spherical_harmonic(s::Int, l::Int, m::Int; method="auto")
-    normalized_method = _normalize_spherical_method(method)
-
-    if normalized_method == "auto"
-        _method = l >= 30 ? "jacobi" : "direct"
-    else
-        _method = normalized_method
+    method = _format_method_name(method)
+    if method == "auto"
+        method = l >= 30 ? "jacobi" : "direct"
     end
 
-    if _method == "direct"
+    if method == "direct"
         return SpinWeightedSphericalHarmonicFunction(s, l, m, spin_weighted_spherical_eigenvalue(s, l, m), :direct, nothing)
-    elseif _method == "chebyshev"
+    elseif method == "chebyshev"
         chebyshev_soln = _solve_spherical_harmonic_chebyshev(s, l, m)
         return SpinWeightedSphericalHarmonicFunction(s, l, m, spin_weighted_spherical_eigenvalue(s, l, m), :chebyshev, chebyshev_soln)
+    elseif method == "jacobi"
+        return SpinWeightedSphericalHarmonicFunction(s, l, m, spin_weighted_spherical_eigenvalue(s, l, m), :jacobi, nothing)
     end
-    return SpinWeightedSphericalHarmonicFunction(s, l, m, spin_weighted_spherical_eigenvalue(s, l, m), :jacobi, nothing)
 end
 
 @doc raw"""
@@ -154,9 +192,12 @@ Additionally compute the `theta_derivative`-th derivative with respect to `theta
     if swsh_func.method == :direct
         return _nth_derivative_spherical_harmonic_direct_eval(swsh_func.s, swsh_func.l, swsh_func.m, theta_derivative, phi_derivative, theta, phi)
     elseif swsh_func.method == :chebyshev
-        return _nth_derivative_spherical_harmonic_chebyshev(swsh_func.chebyshev_solution, swsh_func.s, swsh_func.l, swsh_func.m, theta_derivative, phi_derivative, theta, phi)
+        return _nth_derivative_spheroidal_harmonic_chebyshev(swsh_func.chebyshev_solution, swsh_func.m, theta_derivative, phi_derivative, theta, phi)
+    elseif swsh_func.method == :jacobi
+        return _nth_derivative_spherical_harmonic_jacobi(swsh_func.s, swsh_func.l, swsh_func.m, theta_derivative, phi_derivative, theta, phi)
+    else
+        error("Unknown method $(swsh_func.method) for evaluating spin-weighted spherical harmonic.")
     end
-    return _nth_derivative_spherical_harmonic_jacobi(swsh_func.s, swsh_func.l, swsh_func.m, theta_derivative, phi_derivative, theta, phi)
 end
 
 @doc raw"""

--- a/src/spectral.jl
+++ b/src/spectral.jl
@@ -77,42 +77,51 @@ function construct_spectral_matrix(c, s::Int, m::Int, N::Int)
     spectral_matrix = Array(Symmetric(spectral_matrix))
 end
 
-function angular_sep_const(c, s::Int, l::Int, m::Int, N::Int=-1)
-    if c == 0
-        # Return the Schwarzschild eigenvalue explicitly
-        return eigenvalue_Schwarzschild(s, l)
+function _mode_index_in_matrix(s::Int, l::Int, m::Int, N::Int)
+    lmin = max(abs(m), abs(s))
+    idx = l - lmin + 1
+    if idx < 1 || idx > N
+        error("Target l=$l is outside the spectral matrix range for N=$N")
     end
+    return idx
+end
 
+function _spectral_mode_solution(c, s::Int, l::Int, m::Int, N::Int=-1)
     if N == -1
         N = _determine_matrix_size_N(s, l, m)
     end
 
-    all_l_in_matrix = construct_all_l_in_matrix(s, m, N)
-    spectral_matrix = construct_spectral_matrix(c, s, m, N)
+    idx = _mode_index_in_matrix(s, l, m, N)
 
-    # Solve the eigenvalue problem
-    eigenvalues = eigvals(spectral_matrix)
-    # The returned eigenvalues are already sorted in ascending order
-    eigenvalues[indexin(l, all_l_in_matrix)[1]]
+    if c == 0
+        # In the spherical limit, the decomposition is exactly a Kronecker delta.
+        coeffs = zeros(ComplexF64, N)
+        coeffs[idx] = 1.0 + 0.0im
+        return eigenvalue_Schwarzschild(s, l), coeffs
+    end
+
+    spectral_matrix = construct_spectral_matrix(c, s, m, N)
+    decomposition = eigen(spectral_matrix)
+    angular = decomposition.values[idx]
+    v = decomposition.vectors[:, idx]
+
+    # Fix an overall phase convention and normalize.
+    pivot = v[idx]
+    if pivot != 0
+        v /= pivot
+    end
+    coeffs = v / sqrt(dot(v, v))
+    return angular, coeffs
+end
+
+function angular_sep_const(c, s::Int, l::Int, m::Int, N::Int=-1)
+    angular, _ = _spectral_mode_solution(c, s, l, m, N)
+    angular
 end
 
 function spectral_coefficients(c, s::Int, l::Int, m::Int, N::Int=-1)
-    if N == -1
-        N = _determine_matrix_size_N(s, l, m)
-    end
-
-    all_l_in_matrix = construct_all_l_in_matrix(s, m, N)
-    spectral_matrix = construct_spectral_matrix(c, s, m, N)
-
-    # Solve the eigenvalue problem
-    eigenvectors = eigvecs(spectral_matrix)
-    # The returned eigenvectors are already normalized
-    v = eigenvectors[:,indexin(l, all_l_in_matrix)[1]]
-    # Note that the eigenvectors are determined only up to a multiplicative factor
-    # Make sure that when l'=l, it is a positive real number
-    v /= v[indexin(l, all_l_in_matrix)[1]]
-    # Re-normalize the vector
-    return v/sqrt(dot(v,v))
+    _, coeffs = _spectral_mode_solution(c, s, l, m, N)
+    coeffs
 end
 
 function Teukolsky_lambda_const(c, s::Int, l::Int, m::Int, N::Int=-1)

--- a/src/spectral.jl
+++ b/src/spectral.jl
@@ -77,7 +77,7 @@ function construct_spectral_matrix(c, s::Int, m::Int, N::Int)
     spectral_matrix = Array(Symmetric(spectral_matrix))
 end
 
-function _mode_index_in_matrix(s::Int, l::Int, m::Int, N::Int)
+function _ell_index_in_matrix(s::Int, l::Int, m::Int, N::Int)
     lmin = max(abs(m), abs(s))
     idx = l - lmin + 1
     if idx < 1 || idx > N
@@ -86,12 +86,12 @@ function _mode_index_in_matrix(s::Int, l::Int, m::Int, N::Int)
     return idx
 end
 
-function _spectral_mode_solution(c, s::Int, l::Int, m::Int, N::Int=-1)
+function _spectral_decomposition(c, s::Int, l::Int, m::Int, N::Int=-1)
     if N == -1
         N = _determine_matrix_size_N(s, l, m)
     end
 
-    idx = _mode_index_in_matrix(s, l, m, N)
+    idx = _ell_index_in_matrix(s, l, m, N)
 
     if c == 0
         # In the spherical limit, the decomposition is exactly a Kronecker delta.
@@ -102,7 +102,7 @@ function _spectral_mode_solution(c, s::Int, l::Int, m::Int, N::Int=-1)
 
     spectral_matrix = construct_spectral_matrix(c, s, m, N)
     decomposition = eigen(spectral_matrix)
-    angular = decomposition.values[idx]
+    angular_sep = decomposition.values[idx]
     v = decomposition.vectors[:, idx]
 
     # Fix an overall phase convention and normalize.
@@ -111,17 +111,19 @@ function _spectral_mode_solution(c, s::Int, l::Int, m::Int, N::Int=-1)
         v /= pivot
     end
     coeffs = v / sqrt(dot(v, v))
-    return angular, coeffs
+    return angular_sep, coeffs
 end
 
+# For backwards compatibility, we can still export the old function names that call the new internal function.
 function angular_sep_const(c, s::Int, l::Int, m::Int, N::Int=-1)
-    angular, _ = _spectral_mode_solution(c, s, l, m, N)
-    angular
+    angular_sep, _ = _spectral_decomposition(c, s, l, m, N)
+    return angular_sep
 end
 
+# For backwards compatibility, we can still export the old function names that call the new internal function.
 function spectral_coefficients(c, s::Int, l::Int, m::Int, N::Int=-1)
-    _, coeffs = _spectral_mode_solution(c, s, l, m, N)
-    coeffs
+    _, coeffs = _spectral_decomposition(c, s, l, m, N)
+    return coeffs
 end
 
 function Teukolsky_lambda_const(c, s::Int, l::Int, m::Int, N::Int=-1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,14 @@
 using SpinWeightedSpheroidalHarmonics
 using Test
 
+function _theta_integral_abs2(swsh; n::Int=2001, phi=0.0)
+    thetas = range(0.0, π; length=n)
+    h = step(thetas)
+    vals = [abs2(swsh(θ, phi)) * sin(θ) for θ in thetas]
+    # Trapezoidal rule on [0, π]
+    return h * (sum(vals) - 0.5 * (vals[1] + vals[end]))
+end
+
 @testset "SpinWeightedSpheroidalHarmonics.jl" begin
     @testset "Jacobi spherical harmonic evaluation" begin
         test_modes = [
@@ -36,6 +44,75 @@ using Test
         @test spin_weighted_spherical_harmonic(-2, 40, 2; method="auto").method == :jacobi
     end
 
+    @testset "Jacobi symmetry tricks: m reflection" begin
+        # Jacobi uses a symmetry relation for m < 0. Validate it against
+        # direct evaluation, which is treated as the golden standard.
+        symmetry_pairs = [
+            (-2, 10, 3),
+            (-1, 9, 2),
+            (1, 8, 2),
+            (2, 11, 1),
+        ]
+        symmetry_angles = [
+            (0.42, 0.30),
+            (1.70, -0.80),
+            (2.60, 2.20),
+        ]
+
+        for (s, l, mpos) in symmetry_pairs
+            mneg = -mpos
+            y_jacobi_neg = spin_weighted_spherical_harmonic(s, l, mneg; method="jacobi")
+            y_direct_neg = spin_weighted_spherical_harmonic(s, l, mneg; method="direct")
+            y_direct_ref = spin_weighted_spherical_harmonic(-s, l, mpos; method="direct")
+            phase = (-1)^(s - mneg)
+
+            for (theta, phi) in symmetry_angles
+                # Golden-standard agreement for the negative-m mode.
+                @test y_jacobi_neg(theta, phi) ≈ y_direct_neg(theta, phi) rtol=1e-9 atol=1e-12
+                @test y_jacobi_neg(theta, phi; theta_derivative=1) ≈ y_direct_neg(theta, phi; theta_derivative=1) rtol=1e-9 atol=1e-10
+                @test y_jacobi_neg(theta, phi; theta_derivative=2) ≈ y_direct_neg(theta, phi; theta_derivative=2) rtol=1e-9 atol=1e-9
+
+                # Explicitly check the symmetry trick against direct.
+                @test y_jacobi_neg(theta, phi) ≈ phase * conj(y_direct_ref(theta, phi)) rtol=1e-9 atol=1e-12
+                @test y_jacobi_neg(theta, phi; theta_derivative=1) ≈ phase * conj(y_direct_ref(theta, phi; theta_derivative=1)) rtol=1e-9 atol=1e-10
+                @test y_jacobi_neg(theta, phi; theta_derivative=1, phi_derivative=1) ≈ phase * conj(y_direct_ref(theta, phi; theta_derivative=1, phi_derivative=1)) rtol=1e-9 atol=1e-10
+            end
+        end
+    end
+
+    @testset "Jacobi symmetry tricks: theta folding" begin
+        # Jacobi maps theta to [0, pi] using (theta, phi) -> (2pi-theta, phi+pi)
+        # when needed. Validate this mapping with direct evaluation.
+        fold_modes = [
+            (-2, 8, 2),
+            (-2, 8, -2),
+            (0, 9, 0),
+            (1, 7, -1),
+        ]
+        principal_angles = [
+            (0.70, 0.40),
+            (1.40, -1.10),
+            (2.20, 2.20),
+        ]
+
+        for (s, l, m) in fold_modes
+            y_direct = spin_weighted_spherical_harmonic(s, l, m; method="direct")
+            y_jacobi = spin_weighted_spherical_harmonic(s, l, m; method="jacobi")
+
+            for (theta, phi) in principal_angles
+                theta_folded = 2π - theta
+                theta_negative = -theta
+
+                @test y_jacobi(theta_folded, phi) ≈ y_direct(theta, phi + π) rtol=1e-9 atol=1e-12
+                @test y_jacobi(theta_negative, phi) ≈ y_direct(theta, phi + π) rtol=1e-9 atol=1e-12
+                @test y_jacobi(theta_folded, phi; phi_derivative=2) ≈ y_direct(theta, phi + π; phi_derivative=2) rtol=1e-9 atol=1e-10
+                @test y_jacobi(theta_negative, phi; phi_derivative=2) ≈ y_direct(theta, phi + π; phi_derivative=2) rtol=1e-9 atol=1e-10
+                @test y_jacobi(theta_folded, phi; theta_derivative=1) ≈ y_direct(theta, phi + π; theta_derivative=1) rtol=1e-9 atol=1e-10
+                @test y_jacobi(theta_negative, phi; theta_derivative=1) ≈ y_direct(theta, phi + π; theta_derivative=1) rtol=1e-9 atol=1e-10
+            end
+        end
+    end
+
     @testset "Case-insensitive method options" begin
         @test spin_weighted_spherical_harmonic(-2, 40, 2; method="JaCoBi").method == :jacobi
         @test spin_weighted_spherical_harmonic(-2, 40, 2; method=:CHEBYSHEV).method == :chebyshev
@@ -48,6 +125,35 @@ using Test
         val = y(1.1, 0.4)
         @test isfinite(real(val))
         @test isfinite(imag(val))
+    end
+
+    @testset "Jacobi normalization convention" begin
+        modes = [
+            (-2, 6, 2),
+            (-2, 12, 2),
+            (-1, 15, 1),
+            (0, 20, 0),
+            (2, 18, -1),
+        ]
+
+        for (s, l, m) in modes
+            y_direct = spin_weighted_spherical_harmonic(s, l, m; method="direct")
+            y_jacobi = spin_weighted_spherical_harmonic(s, l, m; method="jacobi")
+
+            norm_direct_phi0 = _theta_integral_abs2(y_direct; phi=0.0)
+            norm_jacobi_phi0 = _theta_integral_abs2(y_jacobi; phi=0.0)
+            norm_direct_phi1 = _theta_integral_abs2(y_direct; phi=1.3)
+            norm_jacobi_phi1 = _theta_integral_abs2(y_jacobi; phi=1.3)
+
+            # Jacobi should match direct normalization for the same mode.
+            @test norm_jacobi_phi0 ≈ norm_direct_phi0 rtol=1e-9 atol=1e-12
+            @test norm_jacobi_phi1 ≈ norm_direct_phi1 rtol=1e-9 atol=1e-12
+
+            # Direct evaluation method follows the package convention:
+            # ∫_0^π |sY_lm(θ, ϕ)|^2 sinθ dθ = 1/(2π), independent of ϕ.
+            @test norm_direct_phi0 ≈ 1 / (2π) rtol=5e-5 atol=5e-7
+            @test norm_direct_phi1 ≈ 1 / (2π) rtol=5e-5 atol=5e-7
+        end
     end
 
     @testset "Spheroidal lambda consistency" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,5 +2,69 @@ using SpinWeightedSpheroidalHarmonics
 using Test
 
 @testset "SpinWeightedSpheroidalHarmonics.jl" begin
-    # Nothing here for now
+    @testset "Jacobi spherical harmonic evaluation" begin
+        test_modes = [
+            (-2, 6, 2),
+            (-2, 6, -2),
+            (-2, 8, 0),
+            (0, 8, -3),
+            (1, 6, -1),
+            (2, 7, 0),
+        ]
+        test_angles = [
+            (0.37, 0.91),
+            (1.10, 2.30),
+            (2.40, -0.20),
+        ]
+
+        for (s, l, m) in test_modes
+            y_direct = spin_weighted_spherical_harmonic(s, l, m; method="direct")
+            y_jacobi = spin_weighted_spherical_harmonic(s, l, m; method="jacobi")
+
+            for (theta, phi) in test_angles
+                @test y_jacobi(theta, phi) ≈ y_direct(theta, phi) rtol=1e-10 atol=1e-12
+                @test y_jacobi(theta, phi; phi_derivative=2) ≈ y_direct(theta, phi; phi_derivative=2) rtol=1e-10 atol=1e-12
+                @test y_jacobi(theta, phi; theta_derivative=1) ≈ y_direct(theta, phi; theta_derivative=1) rtol=1e-8 atol=1e-10
+                @test y_jacobi(theta, phi; theta_derivative=2) ≈ y_direct(theta, phi; theta_derivative=2) rtol=1e-8 atol=1e-9
+                @test y_jacobi(theta, phi; theta_derivative=1, phi_derivative=1) ≈ y_direct(theta, phi; theta_derivative=1, phi_derivative=1) rtol=1e-8 atol=1e-10
+            end
+        end
+    end
+
+    @testset "Auto method selection" begin
+        @test spin_weighted_spherical_harmonic(-2, 10, 2; method="auto").method == :direct
+        @test spin_weighted_spherical_harmonic(-2, 40, 2; method="auto").method == :jacobi
+    end
+
+    @testset "Case-insensitive method options" begin
+        @test spin_weighted_spherical_harmonic(-2, 40, 2; method="JaCoBi").method == :jacobi
+        @test spin_weighted_spherical_harmonic(-2, 40, 2; method=:CHEBYSHEV).method == :chebyshev
+        @test spin_weighted_spherical_harmonic(-2, 10, 2; method="DiReCt").method == :direct
+        @test spin_weighted_spherical_harmonic(-2, 10, 2; method=:AUTO).method == :direct
+    end
+
+    @testset "High-l Jacobi is finite" begin
+        y = spin_weighted_spherical_harmonic(-2, 200, 2; method="jacobi")
+        val = y(1.1, 0.4)
+        @test isfinite(real(val))
+        @test isfinite(imag(val))
+    end
+
+    @testset "Spheroidal lambda consistency" begin
+        s = -2
+        l = 8
+        m = 2
+        c = 0.3
+        swsh = spin_weighted_spheroidal_harmonic(s, l, m, c; method="JaCoBi")
+        @test swsh.lambda ≈ spin_weighted_spheroidal_eigenvalue(s, l, m, c)
+    end
+
+    @testset "Spherical limit (c = 0)" begin
+        s = -2
+        l = 6
+        m = 2
+        spheroidal = spin_weighted_spheroidal_harmonic(s, l, m, 0.0; method="direct")
+        spherical = spin_weighted_spherical_harmonic(s, l, m; method="direct")
+        @test spheroidal(1.1, 0.7) ≈ spherical(1.1, 0.7) rtol=1e-12 atol=1e-12
+    end
 end


### PR DESCRIPTION
As titled. This PR implements the Jacobi recurrence relation shown in Eqs. (10) - (14) in https://arxiv.org/abs/2208.03691 (though note that the recurrence relation for the Jacobi polynomials itself dates way back) for evaluating the Wigner small-d rotation matrices, which are related to the spin-weighted spherical harmonics.

This resolves the precision issue with the direct evaluation method, which in turns necessitates the use of Chebyshev collocation method (which is slow...). Now, with `method="jacobi"`, the code can return the correct value for the harmonics even with a high $\ell$.